### PR TITLE
Make this filter work in Java

### DIFF
--- a/app/com/mohiva/play/htmlcompressor/HTMLCompressorFilter.scala
+++ b/app/com/mohiva/play/htmlcompressor/HTMLCompressorFilter.scala
@@ -42,6 +42,23 @@ class HTMLCompressorFilter(f: => HtmlCompressor) extends Filter {
   lazy val compressor = f
 
   /**
+   * Make this filter work in Java. 
+   */
+  def this() = this({
+    val compressor = new HtmlCompressor()
+    if (Play.isDev) {
+      compressor.setPreserveLineBreaks(true)
+    }
+
+    compressor.setRemoveComments(true)
+    compressor.setRemoveIntertagSpaces(true)
+    compressor.setRemoveHttpProtocol(true)
+    compressor.setRemoveHttpsProtocol(true)
+    compressor
+  })
+
+
+  /**
    * Apply the filter.
    *
    * @param next The action to filter.


### PR DESCRIPTION
Java uses filters a bit differently in the Global.java.
Basically, the class needs a constructor for .newInstance() call by Java ClassLoader.
Also: The html compressor filter needs to be applied before other filters, e.g., the GZIP filter. Therefore, in Java the filter array in Global.java needs a certain order due to right to left processing. The html compress filter needs to be added far right.
