### PR TITLE
[play-2.3] HTML-compressor hangs on processing static HTML assets

### DIFF
--- a/test/com/mohiva/play/htmlcompressor/HTMLCompressorFilterSpec.scala
+++ b/test/com/mohiva/play/htmlcompressor/HTMLCompressorFilterSpec.scala
@@ -48,6 +48,16 @@ class HTMLCompressorFilterSpec extends Specification {
       contentType(result) must beSome("text/plain")
       contentAsString(result) must startWith("  <html/>")
     }
+
+    "compress static assets" in new DefaultCompressorGlobal {
+      val file = scala.io.Source.fromInputStream(Play.resourceAsStream("static.html").get).mkString
+      val Some(result) = route(FakeRequest(GET, "/static"))
+
+      status(result) must equalTo(OK)
+      contentType(result) must beSome("text/html")
+      contentAsString(result) must startWith("<!DOCTYPE html><html><head>")
+      header(CONTENT_LENGTH, result) must not beSome file.length.toString
+    }
   }
 
   "The custom filter" should {
@@ -74,6 +84,16 @@ class HTMLCompressorFilterSpec extends Specification {
       contentType(result) must beSome("text/plain")
       contentAsString(result) must startWith("  <html/>")
     }
+
+    "compress static assets" in new CustomCompressorGlobal {
+      val file = scala.io.Source.fromInputStream(Play.resourceAsStream("static.html").get).mkString
+      val Some(result) = route(FakeRequest(GET, "/static"))
+
+      status(result) must equalTo(OK)
+      contentType(result) must beSome("text/html")
+      contentAsString(result) must startWith("<!DOCTYPE html><html><head>")
+      header(CONTENT_LENGTH, result) must not beSome file.length.toString
+    }
   }
 
   /**
@@ -92,6 +112,7 @@ class HTMLCompressorFilterSpec extends Specification {
         case ("GET", "/action") => Some(new com.mohiva.play.htmlcompressor.fixtures.Application().action)
         case ("GET", "/asyncAction") => Some(new com.mohiva.play.htmlcompressor.fixtures.Application().asyncAction)
         case ("GET", "/nonHTML") => Some(new com.mohiva.play.htmlcompressor.fixtures.Application().nonHTML)
+        case ("GET", "/static") => Some(new com.mohiva.play.htmlcompressor.fixtures.Application().staticAsset)
         case _ => None
       }
     }

--- a/test/com/mohiva/play/htmlcompressor/fixtures/Application.scala
+++ b/test/com/mohiva/play/htmlcompressor/fixtures/Application.scala
@@ -3,11 +3,12 @@ package com.mohiva.play.htmlcompressor.fixtures
 import play.api.mvc._
 import play.twirl.api.Html
 import scala.concurrent.Future
+import controllers.AssetsBuilder
 
 /**
  * Test controller.
  */
-class Application extends Controller {
+class Application extends AssetsBuilder {
 
   /**
    * The template to compress.
@@ -46,4 +47,9 @@ class Application extends Controller {
   def nonHTML = Action {
     Ok("  <html/>")
   }
+
+  /**
+   * Loads a static asset.
+   */
+  def staticAsset = at("/", "static.html")
 }

--- a/test/com/mohiva/play/xmlcompressor/XMLCompressorFilterSpec.scala
+++ b/test/com/mohiva/play/xmlcompressor/XMLCompressorFilterSpec.scala
@@ -15,7 +15,7 @@ import play.api.mvc._
 import play.api.test._
 import play.api.test.Helpers._
 import play.api.test.FakeApplication
-import play.api.GlobalSettings
+import play.api.{ Play, GlobalSettings }
 import com.googlecode.htmlcompressor.compressor.XmlCompressor
 
 /**
@@ -47,6 +47,16 @@ class XMLCompressorFilterSpec extends Specification {
       contentType(result) must beSome("text/plain")
       contentAsString(result) must startWith("  <html/>")
     }
+
+    "compress static XML assets" in new CustomCompressorGlobal {
+      val file = scala.io.Source.fromInputStream(Play.resourceAsStream("static.xml").get).mkString
+      val Some(result) = route(FakeRequest(GET, "/static"))
+
+      status(result) must equalTo(OK)
+      contentType(result) must beSome("application/xml")
+      contentAsString(result) must startWith("<?xml version=\"1.0\"?><node><subnode>")
+      header(CONTENT_LENGTH, result) must not beSome file.length.toString
+    }
   }
 
   "The custom filter" should {
@@ -73,6 +83,16 @@ class XMLCompressorFilterSpec extends Specification {
       contentType(result) must beSome("text/plain")
       contentAsString(result) must startWith("  <html/>")
     }
+
+    "compress static XML assets" in new CustomCompressorGlobal {
+      val file = scala.io.Source.fromInputStream(Play.resourceAsStream("static.xml").get).mkString
+      val Some(result) = route(FakeRequest(GET, "/static"))
+
+      status(result) must equalTo(OK)
+      contentType(result) must beSome("application/xml")
+      contentAsString(result) must startWith("<?xml version=\"1.0\"?><node><subnode>")
+      header(CONTENT_LENGTH, result) must not beSome file.length.toString
+    }
   }
 
   /**
@@ -91,6 +111,7 @@ class XMLCompressorFilterSpec extends Specification {
         case ("GET", "/action") => Some(new com.mohiva.play.xmlcompressor.fixtures.Application().action)
         case ("GET", "/asyncAction") => Some(new com.mohiva.play.xmlcompressor.fixtures.Application().asyncAction)
         case ("GET", "/nonXML") => Some(new com.mohiva.play.xmlcompressor.fixtures.Application().nonXML)
+        case ("GET", "/static") => Some(new com.mohiva.play.xmlcompressor.fixtures.Application().staticAsset)
         case _ => None
       }
     }

--- a/test/com/mohiva/play/xmlcompressor/fixtures/Application.scala
+++ b/test/com/mohiva/play/xmlcompressor/fixtures/Application.scala
@@ -2,11 +2,12 @@ package com.mohiva.play.xmlcompressor.fixtures
 
 import play.api.mvc._
 import scala.concurrent.Future
+import controllers.AssetsBuilder
 
 /**
  * Test controller.
  */
-class Application extends Controller {
+class Application extends AssetsBuilder {
 
   /**
    * The template to compress.
@@ -41,4 +42,9 @@ class Application extends Controller {
   def nonXML = Action {
     Ok("  <html/>")
   }
+
+  /**
+   * Loads a static asset.
+   */
+  def staticAsset = at("/", "static.xml")
 }

--- a/test/resources/static.html
+++ b/test/resources/static.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>@title</title>
+</head>
+<body>
+    I'm a play app
+</body>
+</html>

--- a/test/resources/static.xml
+++ b/test/resources/static.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<node>
+    <subnode>
+        Some text
+    </subnode>
+</node>


### PR DESCRIPTION
play 2.3.1
play-html-compressor 0.3

In short: static HTML files (in `/public/` dir) are compressed by play-html-compressor (it's ok), but NO EOF is sent to client. File content is sent to client, but no close connection, no EOF, etc. Connection just hangs opened forever.

**Disabling play-html-compressor in `Global.scala` fixes the problem.**
There are NO errors nor in play/project/application.log, neither in play console.

Steps to reproduce:
1) Create HTML-file somewhere in `/public/` directory of some play23 project:

```
$ cd somePlay23ProjectRoot/
$ cat > public/dialog.html << EOF
<!DOCTYPE html>
<html>
<body>
    <h3>Custom dialog</h3>
    Input some text: <input id="content">
    <button onclick="top.tinymce.activeEditor.windowManager.getWindows()[0].close();">Close window</button>
</body>
</html>
EOF
```

2) Enable html compression filter in `Global.scala`. Compression settings does not matter:

```
object Global extends WithFilters(MyHTMLCompressorFilter()) {
...
}
object MyHTMLCompressorFilter {
  def apply() = {
    val compressor = new HtmlCompressor()
    compressor.setPreserveLineBreaks(true)
    compressor.setRemoveComments(false)
    compressor.setRemoveIntertagSpaces(true)
    compressor.setRemoveHttpProtocol(false)
    compressor.setRemoveHttpsProtocol(false)
    new HTMLCompressorFilter(compressor)
  }
}
```

3) Make GET request for static html file:

```
$ curl -v localhost:9000/assets/dialog.html
* Hostname was NOT found in DNS cache
*   Trying ::1...
* Connected to localhost (::1) port 9000 (#0)
> GET /assets/dialog.html HTTP/1.1
> User-Agent: curl/7.37.0
> Host: localhost:9000
> Accept: */*
> 
< HTTP/1.1 200 OK
< Cache-Control: no-cache
< Content-Length: 213
< Content-Type: text/html; charset=utf-8
< Date: Wed, 02 Jul 2014 12:48:07 GMT
< ETag: "1cff498d002d3c3aaef8bc7c10abac73dec3d7ba"
< Last-Modified: Thu, 26 Jun 2014 15:18:42 GMT
< 
<!DOCTYPE html>
<html>
<body>
<h3>Custom dialog</h3>
Input some text: <input id="content">
<button onclick="top.tinymce.activeEditor.windowManager.getWindows()[0].close();">Close window</button>
</body>
--- AND IT JUST HANGS HERE FOREVER, NO EOF ---
--- AND IT JUST HANGS HERE FOREVER, NO EOF ---
--- AND IT JUST HANGS HERE FOREVER, NO EOF ---
```

If make request via nginx, something like this occurs:

```
$ curl https://.../assets/dialog.html
curl: (18) transfer closed with 9 bytes remaining to read
<!DOCTYPE html><html><body><h3>Custom dialog</h3> Input some text: <input id="content"><button onclick="top.tinymce.activeEditor.windowManager.getWindows()[0].close();">Close window</button></body></html>%
```
