### PR TITLE
Update README.md to point to Sonatype via https

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ libraryDependencies ++= Seq(
 
 If you want to use the latest snapshot, add the following instead:
 ```scala
-resolvers += "Sonatype Snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
+resolvers += "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 
 libraryDependencies ++= Seq(
   "com.mohiva" %% "play-html-compressor" % "0.4-SNAPSHOT"


### PR DESCRIPTION
... because http won't work anymore.
