### PR TITLE
Changed compressor filters to skip compressing if result is returned with transfer encoding set to chunked

### DIFF
--- a/app/com/mohiva/play/compressor/CompressorFilter.scala
+++ b/app/com/mohiva/play/compressor/CompressorFilter.scala
@@ -1,5 +1,6 @@
 package com.mohiva.play.compressor
 
+import play.api.http.HttpProtocol
 import play.twirl.api.Content
 import play.api.mvc._
 import play.api.Play
@@ -45,7 +46,9 @@ abstract class CompressorFilter[C <: Compressor](f: => C) extends Filter {
    * @param result The result to check.
    * @return True if the result is a compressible result, false otherwise.
    */
-  protected def isCompressible(result: Result): Boolean
+  protected def isCompressible(result: Result): Boolean = {
+    !result.header.headers.get(TRANSFER_ENCODING).contains(HttpProtocol.CHUNKED)
+  }
 
   /**
    * Compress the result.

--- a/app/com/mohiva/play/htmlcompressor/HTMLCompressorFilter.scala
+++ b/app/com/mohiva/play/htmlcompressor/HTMLCompressorFilter.scala
@@ -32,10 +32,10 @@ class HTMLCompressorFilter(f: => HtmlCompressor) extends CompressorFilter[HtmlCo
    * @param result The result to check.
    * @return True if the result is a HTML result, false otherwise.
    */
-  protected def isCompressible(result: Result): Boolean = {
-    result.header.headers.contains(HeaderNames.CONTENT_TYPE) &&
-      result.header.headers.apply(HeaderNames.CONTENT_TYPE).contains(MimeTypes.HTML) &&
-      manifest[Enumerator[Html]].runtimeClass.isInstance(result.body)
+  override protected def isCompressible(result: Result): Boolean = {
+    lazy val contentTypeHtml = result.header.headers.get(HeaderNames.CONTENT_TYPE).exists(_.contains(MimeTypes.HTML))
+    lazy val htmlEnumerator = manifest[Enumerator[Html]].runtimeClass.isInstance(result.body)
+    super.isCompressible(result) && contentTypeHtml && htmlEnumerator
   }
 }
 

--- a/app/com/mohiva/play/xmlcompressor/XMLCompressorFilter.scala
+++ b/app/com/mohiva/play/xmlcompressor/XMLCompressorFilter.scala
@@ -30,11 +30,11 @@ class XMLCompressorFilter(f: => XmlCompressor) extends CompressorFilter[XmlCompr
    * @param result The result to check.
    * @return True if the result is a XML result, false otherwise.
    */
-  protected def isCompressible(result: Result) = {
-    result.header.headers.contains(HeaderNames.CONTENT_TYPE) &&
-      // We cannot simply look for MimeTypes.XML because of things like "application/atom+xml".
-      result.header.headers.apply(HeaderNames.CONTENT_TYPE).contains("xml") &&
-      manifest[Enumerator[Xml]].runtimeClass.isInstance(result.body)
+  override protected def isCompressible(result: Result) = {
+    // We cannot simply look for MimeTypes.XML because of things like "application/atom+xml".
+    lazy val contentTypeXml = result.header.headers.get(HeaderNames.CONTENT_TYPE).exists(_.contains("xml"))
+    lazy val xmlEnumerator = manifest[Enumerator[Xml]].runtimeClass.isInstance(result.body)
+    super.isCompressible(result) && contentTypeXml && xmlEnumerator
   }
 }
 

--- a/test/com/mohiva/play/htmlcompressor/HTMLCompressorFilterSpec.scala
+++ b/test/com/mohiva/play/htmlcompressor/HTMLCompressorFilterSpec.scala
@@ -10,6 +10,7 @@
  */
 package com.mohiva.play.htmlcompressor
 
+import com.mohiva.play.htmlcompressor.fixtures.Application
 import org.specs2.mutable._
 import play.api.mvc._
 import play.api.test._
@@ -57,6 +58,13 @@ class HTMLCompressorFilterSpec extends Specification {
       contentType(result) must beSome("text/html")
       contentAsString(result) must startWith("<!DOCTYPE html> <html> <head>")
       header(CONTENT_LENGTH, result) must not beSome file.length.toString
+    }
+
+    "not compress result with chunked HTML result" in new DefaultCompressorGlobal {
+      val Some(result) = route(FakeRequest(GET, "/chunked"))
+      status(result) must beEqualTo(OK)
+      contentType(result) must beSome("text/html")
+      header(CONTENT_LENGTH, result) must beNone
     }
   }
 
@@ -108,11 +116,13 @@ class HTMLCompressorFilterSpec extends Specification {
      * @return An action to handle this request.
      */
     override def onRouteRequest(request: RequestHeader): Option[Handler] = {
+      lazy val application = new Application()
       (request.method, request.path) match {
-        case ("GET", "/action") => Some(new com.mohiva.play.htmlcompressor.fixtures.Application().action)
-        case ("GET", "/asyncAction") => Some(new com.mohiva.play.htmlcompressor.fixtures.Application().asyncAction)
-        case ("GET", "/nonHTML") => Some(new com.mohiva.play.htmlcompressor.fixtures.Application().nonHTML)
-        case ("GET", "/static") => Some(new com.mohiva.play.htmlcompressor.fixtures.Application().staticAsset)
+        case ("GET", "/action") => Some(application.action)
+        case ("GET", "/asyncAction") => Some(application.asyncAction)
+        case ("GET", "/nonHTML") => Some(application.nonHTML)
+        case ("GET", "/static") => Some(application.staticAsset)
+        case ("GET", "/chunked") => Some(application.chunked)
         case _ => None
       }
     }

--- a/test/com/mohiva/play/htmlcompressor/fixtures/Application.scala
+++ b/test/com/mohiva/play/htmlcompressor/fixtures/Application.scala
@@ -1,9 +1,11 @@
 package com.mohiva.play.htmlcompressor.fixtures
 
+import play.api.libs.iteratee.Enumerator
 import play.api.mvc._
 import play.twirl.api.Html
 import scala.concurrent.Future
 import controllers.AssetsBuilder
+import scala.concurrent.ExecutionContext.Implicits.global
 
 /**
  * Test controller.
@@ -52,4 +54,12 @@ class Application extends AssetsBuilder {
    * Loads a static asset.
    */
   def staticAsset = at("/", "static.html")
+
+  /**
+   * Action with chunked transfer encoding
+   */
+  def chunked = Action {
+    val parts = List(" <html> ", " <body> ", " <h1> Title </h1>", " </body> ", " </html> ").map(Html.apply)
+    Ok.chunked(Enumerator.enumerate(parts))
+  }
 }

--- a/test/com/mohiva/play/xmlcompressor/XMLCompressorFilterSpec.scala
+++ b/test/com/mohiva/play/xmlcompressor/XMLCompressorFilterSpec.scala
@@ -10,6 +10,7 @@
  */
 package com.mohiva.play.xmlcompressor
 
+import com.mohiva.play.xmlcompressor.fixtures.Application
 import org.specs2.mutable._
 import play.api.mvc._
 import play.api.test._
@@ -46,6 +47,14 @@ class XMLCompressorFilterSpec extends Specification {
       status(result) must equalTo(OK)
       contentType(result) must beSome("text/plain")
       contentAsString(result) must startWith("  <html/>")
+    }
+
+    "not compress chunked XML result" in new DefaultCompressorGlobal {
+      val Some(result) = route(FakeRequest(GET, "/chunked"))
+
+      status(result) must equalTo(OK)
+      contentType(result) must beSome("application/xml")
+      header(CONTENT_LENGTH, result) must beNone
     }
 
     "compress static XML assets" in new CustomCompressorGlobal {
@@ -107,11 +116,13 @@ class XMLCompressorFilterSpec extends Specification {
      * @return An action to handle this request.
      */
     override def onRouteRequest(request: RequestHeader): Option[Handler] = {
+      lazy val application = new Application()
       (request.method, request.path) match {
-        case ("GET", "/action") => Some(new com.mohiva.play.xmlcompressor.fixtures.Application().action)
-        case ("GET", "/asyncAction") => Some(new com.mohiva.play.xmlcompressor.fixtures.Application().asyncAction)
-        case ("GET", "/nonXML") => Some(new com.mohiva.play.xmlcompressor.fixtures.Application().nonXML)
-        case ("GET", "/static") => Some(new com.mohiva.play.xmlcompressor.fixtures.Application().staticAsset)
+        case ("GET", "/action") => Some(application.action)
+        case ("GET", "/asyncAction") => Some(application.asyncAction)
+        case ("GET", "/nonXML") => Some(application.nonXML)
+        case ("GET", "/static") => Some(application.staticAsset)
+        case ("GET", "/chunked") => Some(application.chunked)
         case _ => None
       }
     }

--- a/test/com/mohiva/play/xmlcompressor/fixtures/Application.scala
+++ b/test/com/mohiva/play/xmlcompressor/fixtures/Application.scala
@@ -1,8 +1,11 @@
 package com.mohiva.play.xmlcompressor.fixtures
 
+import play.api.libs.iteratee.Enumerator
 import play.api.mvc._
+import play.twirl.api.Xml
 import scala.concurrent.Future
 import controllers.AssetsBuilder
+import scala.concurrent.ExecutionContext.Implicits.global
 
 /**
  * Test controller.
@@ -47,4 +50,12 @@ class Application extends AssetsBuilder {
    * Loads a static asset.
    */
   def staticAsset = at("/", "static.xml")
+
+  /**
+   * Action with chunked transfer encoding
+   */
+  def chunked = Action {
+    val parts = List(" <node> ", " <subnode> ", " text", " </subnode> ", " </node> ").map(Xml.apply)
+    Ok.chunked(Enumerator.enumerate(parts))
+  }
 }

--- a/test/com/mohiva/play/xmlcompressor/java/XMLCompressorFilterTest.java
+++ b/test/com/mohiva/play/xmlcompressor/java/XMLCompressorFilterTest.java
@@ -12,6 +12,7 @@ package com.mohiva.play.xmlcompressor.java;
 
 import com.googlecode.htmlcompressor.compressor.XmlCompressor;
 
+import com.mohiva.play.xmlcompressor.fixtures.Application;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
@@ -104,6 +105,22 @@ public class XMLCompressorFilterTest {
     }
 
     /**
+     * Test if the default filter does not compress chunked XML result.
+     */
+    @Test
+    public void defaultFilterNotCompressChunkedXMLPage() {
+        running(fakeApplication(new DefaultCompressorGlobal()), new Runnable() {
+            public void run() {
+                Result result = route(fakeRequest(GET, "/chunked"));
+
+                assertThat(status(result)).isEqualTo(OK);
+                assertThat(contentType(result)).isEqualTo("application/xml");
+                assertThat(header(CONTENT_LENGTH, result)).isNull();
+            }
+        });
+    }
+
+    /**
      * Test if the custom filter compress an XML page.
      */
     @Test
@@ -187,14 +204,18 @@ public class XMLCompressorFilterTest {
          * @return An action to handle this request.
          */
         public play.api.mvc.Handler onRouteRequest(Http.RequestHeader request) {
-            if (request.method().equals("GET") && request.path().equals("/action")) {
-                return new com.mohiva.play.xmlcompressor.fixtures.Application().action();
-            } else if (request.method().equals("GET") && request.path().equals("/asyncAction")) {
-                return new com.mohiva.play.xmlcompressor.fixtures.Application().asyncAction();
-            } else if (request.method().equals("GET") && request.path().equals("/nonXML")) {
-                return new com.mohiva.play.xmlcompressor.fixtures.Application().nonXML();
-            } else if (request.method().equals("GET") && request.path().equals("/static")) {
-                return new com.mohiva.play.xmlcompressor.fixtures.Application().staticAsset();
+            final boolean getRequest = request.method().equals("GET");
+            if (!getRequest) return null;
+            if (request.path().equals("/action")) {
+                return new Application().action();
+            } else if (request.path().equals("/asyncAction")) {
+                return new Application().asyncAction();
+            } else if (request.path().equals("/nonXML")) {
+                return new Application().nonXML();
+            } else if (request.path().equals("/static")) {
+                return new Application().staticAsset();
+            } else if (request.path().equals("/chunked")) {
+                return new Application().chunked();
             } else {
                 return null;
             }


### PR DESCRIPTION
Current implementation of filters is not aware of responses with chunked transfer encoding. These response end up being broken, because `Transfer-Encoding` header is removed, `Content-Length` header is added and chunk sizes are treated as part of the document. Moreover response is blocked on the filter level until enumerator is exhausted.

This change makes filters treat said responses as not possible to compress. 
