### PR TITLE
Fixed compatibility issue with Play Framework 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
 In your project/Build.scala:
 ```scala
 libraryDependencies ++= Seq(
-  "com.mohiva" %% "play-html-compressor" % "0.5.0"
+  "com.mohiva" %% "play-html-compressor" % "0.6.0"
 )
 ```
 
 ### History
 
+* For Play Framework 2.5 use version 0.6.0
 * For Play Framework 2.4 use version 0.5.0
 * For Play Framework 2.3 use version 0.3.1
 * For Play Framework 2.2 use version 0.2.1
@@ -105,12 +106,13 @@ you must provide the bindings for you created filter and disable the default DI 
 ```scala
 import javax.inject.Inject
 
+import akka.stream.Materializer
 import com.googlecode.htmlcompressor.compressor.HtmlCompressor
 import com.mohiva.play.htmlcompressor.HTMLCompressorFilter
 import play.api.{Configuration, Environment, Mode}
 
 class CustomHTMLCompressorFilter @Inject() (
-  val configuration: Configuration, environment: Environment)
+  val configuration: Configuration, environment: Environment, val mat: Materializer)
   extends HTMLCompressorFilter {
 
   override val compressor: HtmlCompressor = {
@@ -132,6 +134,7 @@ class CustomHTMLCompressorFilter @Inject() (
 ##### For Java users
 
 ```java
+import akka.stream.Materializer;
 import com.googlecode.htmlcompressor.compressor.HtmlCompressor;
 import com.mohiva.play.htmlcompressor.HTMLCompressorFilter;
 import play.Environment;
@@ -144,13 +147,15 @@ public class CustomHTMLCompressorFilter extends HTMLCompressorFilter {
 
     private Configuration configuration;
     private Environment environment;
+    private Materializer mat;
 
     @Inject
     public CustomHTMLCompressorFilter(
-        Configuration configuration, Environment environment) {
+        Configuration configuration, Environment environment, Materializer mat) {
         
         this.configuration = configuration;
         this.environment = environment;
+        this.mat = mat;
     }
 
     @Override
@@ -172,6 +177,12 @@ public class CustomHTMLCompressorFilter extends HTMLCompressorFilter {
 
         return compressor;
     }
+    
+    @Override
+    public Materializer mat() {
+        return mat;
+    }
+        
 }
 
 ```
@@ -180,8 +191,8 @@ public class CustomHTMLCompressorFilter extends HTMLCompressorFilter {
 
 To provide your bindings for your user defined filter you must either create a new module 
 or you can add the binding to your default DI module. This process is detailed documented 
-for [Scala](https://www.playframework.com/documentation/2.4.x/ScalaDependencyInjection) and 
-[Java](https://www.playframework.com/documentation/2.4.x/JavaDependencyInjection) users. So 
+for [Scala](https://www.playframework.com/documentation/2.5.x/ScalaDependencyInjection) and 
+[Java](https://www.playframework.com/documentation/2.5.x/JavaDependencyInjection) users. So 
 please refer to this documentation.
 
 ##### Disable default modules

--- a/app/com/mohiva/play/compressor/CompressorFilter.scala
+++ b/app/com/mohiva/play/compressor/CompressorFilter.scala
@@ -10,15 +10,17 @@
  */
 package com.mohiva.play.compressor
 
-import play.api.http.HttpProtocol
-import play.twirl.api.Content
-import play.api.mvc._
+import akka.stream.Materializer
+import akka.stream.scaladsl._
+import akka.util.ByteString
+import com.googlecode.htmlcompressor.compressor.Compressor
 import play.api.Configuration
 import play.api.http.HeaderNames._
-import play.api.libs.iteratee.{ Enumerator, Iteratee }
-import scala.concurrent.Future
+import play.api.http.{HttpEntity, HttpProtocol}
+import play.api.mvc._
+
 import scala.concurrent.ExecutionContext.Implicits.global
-import com.googlecode.htmlcompressor.compressor.Compressor
+import scala.concurrent.Future
 
 /**
  * Base implementation of a filter which makes it possible to compress either HTML or XML with the
@@ -45,13 +47,20 @@ abstract class CompressorFilter[C <: Compressor] extends Filter {
   lazy val charset = configuration.getString("default.charset").getOrElse("utf-8")
 
   /**
+    * Materializer for the Filter.
+    */
+  override implicit val mat: Materializer
+
+  /**
    * Apply the filter.
    *
    * @param next The action to filter.
    * @return The filtered action.
    */
   def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader) = {
-    next(rh).flatMap(result => compressResult(result))
+    next(rh).flatMap(result =>
+      compressResult(result)
+    )
   }
 
   /**
@@ -61,9 +70,10 @@ abstract class CompressorFilter[C <: Compressor] extends Filter {
    * @return True if the result is a compressible result, false otherwise.
    */
   protected def isCompressible(result: Result): Boolean = {
-    val isChunked = result.header.headers.get(TRANSFER_ENCODING).exists(_ == HttpProtocol.CHUNKED)
-    val isGzipped = result.header.headers.get(CONTENT_ENCODING).exists(_ == "gzip")
-    !isChunked && !isGzipped
+    val isChunked = result.header.headers.get(TRANSFER_ENCODING).contains(HttpProtocol.CHUNKED)
+    val isGzipped = result.header.headers.get(CONTENT_ENCODING).contains("gzip")
+    val ret = !isChunked && !isGzipped
+    ret
   }
 
   /**
@@ -72,31 +82,29 @@ abstract class CompressorFilter[C <: Compressor] extends Filter {
    * @param result The result to compress.
    * @return The compressed result.
    */
-  private def compressResult(result: Result): Future[Result] = if (isCompressible(result)) {
-    Iteratee.flatten(result.body.apply(bodyAsString)).run.map { str =>
-      val compressed = compressor.compress(str.trim).getBytes(charset)
-      val length = compressed.length
-      length -> Enumerator(compressed)
-    }.map {
-      case (length, content) =>
-        result.copy(
-          header = result.header.copy(headers = result.header.headers ++ Map(CONTENT_LENGTH -> length.toString)),
-          body = Enumerator.flatten(Future.successful(content))
-        )
-    }
-  } else Future.successful(result)
+  private def compressResult(result: Result): Future[Result] = {
 
-  /**
-   * Converts the body of a result as string.
-   *
-   * @return The body of a result as string.
-   */
-  private def bodyAsString[A] = Iteratee.fold[A, String]("") { (str, body) =>
-    body match {
-      case string: String => str + string
-      case template: Content => str + template.body
-      case bytes: Array[Byte] => str + new String(bytes, charset)
-      case _ => throw new Exception("Unexpected body: " + body)
+    def compress(data: ByteString) = compressor.compress(data.decodeString(charset).trim).getBytes(charset)
+
+    if (isCompressible(result)) {
+      result.body match {
+        case HttpEntity.Strict(data, contentType) =>
+          Future.successful(Result(result.header, HttpEntity.Strict(ByteString(compress(data)), contentType)))
+        case HttpEntity.Streamed(data, _, contentType) =>
+          data.toMat(Sink.fold(ByteString())(_ ++ _))(Keep.right).run() map { bytes =>
+            val compressed = compress(bytes)
+            val length = compressed.length
+            Result(
+              result.header.copy(headers = result.header.headers ++ Map(CONTENT_LENGTH -> length.toString)),
+              HttpEntity.Streamed(Source.single(ByteString(compressed)), Some(length.toLong), result.body.contentType)
+            )
+          }
+        case _ =>
+          Future.successful(result)
+      }
+    } else {
+      Future.successful(result)
     }
   }
+
 }

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ import xerial.sbt.Sonatype._
 
 name := "play-html-compressor"
 
-version := "0.5.0"
+version := "0.6.0"
 
 libraryDependencies ++= Seq(
   "com.googlecode.htmlcompressor" % "htmlcompressor" % "1.5.2",
@@ -62,7 +62,7 @@ pomExtra := pom
 // Compiler settings
 //*******************************
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 crossScalaVersions := Seq("2.10.5", "2.11.7")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 

--- a/test/com/mohiva/play/compressor/Helper.scala
+++ b/test/com/mohiva/play/compressor/Helper.scala
@@ -13,6 +13,7 @@ package com.mohiva.play.compressor
 import java.io.ByteArrayInputStream
 import java.util.zip.GZIPInputStream
 
+import akka.util.ByteString
 import org.apache.commons.io.IOUtils
 
 /**
@@ -26,7 +27,7 @@ object Helper {
    * @param data The data to unzip.
    * @return The unzipped data.
    */
-  def gunzip(data: Array[Byte]): Array[Byte] = {
-    IOUtils.toByteArray(new GZIPInputStream(new ByteArrayInputStream(data)))
+  def gunzip(data: ByteString): ByteString = {
+    ByteString(IOUtils.toByteArray(new GZIPInputStream(new ByteArrayInputStream(data.toArray))))
   }
 }

--- a/test/com/mohiva/play/htmlcompressor/fixtures/Filters.scala
+++ b/test/com/mohiva/play/htmlcompressor/fixtures/Filters.scala
@@ -12,6 +12,7 @@ package com.mohiva.play.htmlcompressor.fixtures
 
 import javax.inject.Inject
 
+import akka.stream.Materializer
 import com.googlecode.htmlcompressor.compressor.HtmlCompressor
 import com.mohiva.play.htmlcompressor.HTMLCompressorFilter
 import play.api.{ Environment, Mode, Configuration }
@@ -22,7 +23,7 @@ import play.filters.gzip.GzipFilter
 /**
  * A custom HTML compressor filter.
  */
-class CustomHTMLCompressorFilter @Inject() (val configuration: Configuration, environment: Environment)
+class CustomHTMLCompressorFilter @Inject() (val configuration: Configuration, environment: Environment, val mat: Materializer)
     extends HTMLCompressorFilter {
 
   override val compressor: HtmlCompressor = {

--- a/test/com/mohiva/play/htmlcompressor/fixtures/TestController.scala
+++ b/test/com/mohiva/play/htmlcompressor/fixtures/TestController.scala
@@ -10,7 +10,10 @@
  */
 package com.mohiva.play.htmlcompressor.fixtures
 
-import play.api.http.DefaultHttpErrorHandler
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import play.api.http.HttpChunk.Chunk
+import play.api.http.{MimeTypes, HttpEntity, DefaultHttpErrorHandler}
 import play.api.libs.iteratee.Enumerator
 import play.api.mvc._
 import play.twirl.api.Html
@@ -44,14 +47,14 @@ class TestController extends AssetsBuilder(DefaultHttpErrorHandler) {
    * A default action.
    */
   def action = Action {
-    Ok(template)
+    Ok(template).as("text/html")
   }
 
   /**
    * A async action.
    */
   def asyncAction = Action.async {
-    Future.successful(Ok(template))
+    Future.successful(Ok(template).as("text/html"))
   }
 
   /**
@@ -70,8 +73,8 @@ class TestController extends AssetsBuilder(DefaultHttpErrorHandler) {
    * Action with chunked transfer encoding.
    */
   def chunked = Action {
-    val parts = List(" <html> ", " <body> ", " <h1> Title </h1>", " </body> ", " </html> ").map(Html.apply)
-    Ok.chunked(Enumerator.enumerate(parts))
+    val parts = List(" <html> ", " <body> ", " <h1> Title </h1>", " </body> ", " </html> ").map(html => ByteString(html))
+    Ok.chunked(Source(parts)).as("text/html")
   }
 
   /**

--- a/test/com/mohiva/play/htmlcompressor/fixtures/java/CustomHTMLCompressorFilter.java
+++ b/test/com/mohiva/play/htmlcompressor/fixtures/java/CustomHTMLCompressorFilter.java
@@ -10,6 +10,7 @@
  */
 package com.mohiva.play.htmlcompressor.fixtures.java;
 
+import akka.stream.Materializer;
 import com.googlecode.htmlcompressor.compressor.HtmlCompressor;
 import com.mohiva.play.htmlcompressor.HTMLCompressorFilter;
 import play.Environment;
@@ -25,11 +26,13 @@ public class CustomHTMLCompressorFilter extends HTMLCompressorFilter {
 
     private Configuration configuration;
     private Environment environment;
+    private Materializer mat;
 
     @Inject
-    public CustomHTMLCompressorFilter(Configuration configuration, Environment environment) {
+    public CustomHTMLCompressorFilter(Configuration configuration, Environment environment, Materializer mat) {
         this.configuration = configuration;
         this.environment = environment;
+        this.mat = mat;
     }
 
     @Override
@@ -50,5 +53,10 @@ public class CustomHTMLCompressorFilter extends HTMLCompressorFilter {
         compressor.setRemoveHttpsProtocol(true);
 
         return compressor;
+    }
+
+    @Override
+    public Materializer mat() {
+        return mat;
     }
 }

--- a/test/com/mohiva/play/htmlcompressor/fixtures/java/DefaultFilter.java
+++ b/test/com/mohiva/play/htmlcompressor/fixtures/java/DefaultFilter.java
@@ -11,7 +11,7 @@
 package com.mohiva.play.htmlcompressor.fixtures.java;
 
 import com.mohiva.play.htmlcompressor.HTMLCompressorFilter;
-import play.api.mvc.EssentialFilter;
+import play.mvc.EssentialFilter;
 import play.http.HttpFilters;
 
 import javax.inject.Inject;
@@ -30,6 +30,6 @@ public class DefaultFilter implements HttpFilters {
 
     @Override
     public EssentialFilter[] filters() {
-        return new EssentialFilter[] {htmlCompressorFilter};
+        return new EssentialFilter[] {htmlCompressorFilter.asJava()};
     }
 }

--- a/test/com/mohiva/play/htmlcompressor/fixtures/java/WithGzipFilter.java
+++ b/test/com/mohiva/play/htmlcompressor/fixtures/java/WithGzipFilter.java
@@ -11,7 +11,7 @@
 package com.mohiva.play.htmlcompressor.fixtures.java;
 
 import com.mohiva.play.htmlcompressor.HTMLCompressorFilter;
-import play.api.mvc.EssentialFilter;
+import play.mvc.EssentialFilter;
 import play.filters.gzip.GzipFilter;
 import play.http.HttpFilters;
 
@@ -33,6 +33,6 @@ public class WithGzipFilter implements HttpFilters {
 
     @Override
     public EssentialFilter[] filters() {
-        return new EssentialFilter[] {gzip, htmlCompressor};
+        return new EssentialFilter[] {gzip.asJava(), htmlCompressor.asJava()};
     }
 }

--- a/test/com/mohiva/play/xmlcompressor/fixtures/Filters.scala
+++ b/test/com/mohiva/play/xmlcompressor/fixtures/Filters.scala
@@ -12,6 +12,7 @@ package com.mohiva.play.xmlcompressor.fixtures
 
 import javax.inject.Inject
 
+import akka.stream.Materializer
 import com.googlecode.htmlcompressor.compressor.XmlCompressor
 import com.mohiva.play.xmlcompressor.XMLCompressorFilter
 import play.api.Configuration
@@ -22,7 +23,7 @@ import play.filters.gzip.GzipFilter
 /**
  * A custom XML compressor filter.
  */
-class CustomXMLCompressorFilter @Inject() (val configuration: Configuration) extends XMLCompressorFilter {
+class CustomXMLCompressorFilter @Inject() (val configuration: Configuration, val mat: Materializer) extends XMLCompressorFilter {
   override val compressor = {
     val c = new XmlCompressor()
     c.setRemoveComments(false)

--- a/test/com/mohiva/play/xmlcompressor/fixtures/TestController.scala
+++ b/test/com/mohiva/play/xmlcompressor/fixtures/TestController.scala
@@ -10,6 +10,8 @@
  */
 package com.mohiva.play.xmlcompressor.fixtures
 
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
 import controllers.AssetsBuilder
 import play.api.http.DefaultHttpErrorHandler
 import play.api.libs.iteratee.Enumerator
@@ -67,8 +69,8 @@ class TestController extends AssetsBuilder(DefaultHttpErrorHandler) {
    * Action with chunked transfer encoding.
    */
   def chunked = Action {
-    val parts = List(" <node> ", " <subnode> ", " text", " </subnode> ", " </node> ").map(Xml.apply)
-    Ok.chunked(Enumerator.enumerate(parts))
+    val parts = List(" <node> ", " <subnode> ", " text", " </subnode> ", " </node> ").map(xml => ByteString(xml))
+    Ok.chunked(Source(parts)).as("application/xml")
   }
 
   /**

--- a/test/com/mohiva/play/xmlcompressor/fixtures/java/CustomXMLCompressorFilter.java
+++ b/test/com/mohiva/play/xmlcompressor/fixtures/java/CustomXMLCompressorFilter.java
@@ -10,6 +10,7 @@
  */
 package com.mohiva.play.xmlcompressor.fixtures.java;
 
+import akka.stream.Materializer;
 import com.googlecode.htmlcompressor.compressor.XmlCompressor;
 import com.mohiva.play.xmlcompressor.XMLCompressorFilter;
 import play.api.Configuration;
@@ -22,10 +23,12 @@ import javax.inject.Inject;
 public class CustomXMLCompressorFilter extends XMLCompressorFilter {
 
     private Configuration configuration;
+    private Materializer mat;
 
     @Inject
-    public CustomXMLCompressorFilter(Configuration configuration) {
+    public CustomXMLCompressorFilter(Configuration configuration, Materializer mat) {
         this.configuration = configuration;
+        this.mat = mat;
     }
 
     @Override
@@ -39,5 +42,10 @@ public class CustomXMLCompressorFilter extends XMLCompressorFilter {
         compressor.setRemoveComments(false);
 
         return compressor;
+    }
+
+    @Override
+    public Materializer mat() {
+        return mat;
     }
 }

--- a/test/com/mohiva/play/xmlcompressor/fixtures/java/DefaultFilter.java
+++ b/test/com/mohiva/play/xmlcompressor/fixtures/java/DefaultFilter.java
@@ -11,7 +11,7 @@
 package com.mohiva.play.xmlcompressor.fixtures.java;
 
 import com.mohiva.play.xmlcompressor.XMLCompressorFilter;
-import play.api.mvc.EssentialFilter;
+import play.mvc.EssentialFilter;
 import play.http.HttpFilters;
 
 import javax.inject.Inject;
@@ -30,6 +30,6 @@ public class DefaultFilter implements HttpFilters {
 
     @Override
     public EssentialFilter[] filters() {
-        return new EssentialFilter[] {xmlCompressorFilter};
+        return new EssentialFilter[] {xmlCompressorFilter.asJava()};
     }
 }

--- a/test/com/mohiva/play/xmlcompressor/fixtures/java/WithGzipFilter.java
+++ b/test/com/mohiva/play/xmlcompressor/fixtures/java/WithGzipFilter.java
@@ -11,7 +11,7 @@
 package com.mohiva.play.xmlcompressor.fixtures.java;
 
 import com.mohiva.play.xmlcompressor.XMLCompressorFilter;
-import play.api.mvc.EssentialFilter;
+import play.mvc.EssentialFilter;
 import play.filters.gzip.GzipFilter;
 import play.http.HttpFilters;
 
@@ -33,6 +33,6 @@ public class WithGzipFilter implements HttpFilters {
 
     @Override
     public EssentialFilter[] filters() {
-        return new EssentialFilter[] {gzip, xmlCompressorFilter};
+        return new EssentialFilter[] {gzip.asJava(), xmlCompressorFilter.asJava()};
     }
 }


### PR DESCRIPTION
This pull request fixes issue #46 .
Play's transition to Akka Streams and new Result types called for some major changes in the filter architecture and thus the proposed version (0.6.0) is **incompatible** with Play versions prior to 2.5.