### PR TITLE
NettyModelConversion (l.189) computes the content length it self

### DIFF
--- a/app/com/mohiva/play/compressor/CompressorFilter.scala
+++ b/app/com/mohiva/play/compressor/CompressorFilter.scala
@@ -95,7 +95,7 @@ abstract class CompressorFilter[C <: Compressor] extends Filter {
             val compressed = compress(bytes)
             val length = compressed.length
             Result(
-              result.header.copy(headers = result.header.headers ++ Map(CONTENT_LENGTH -> length.toString)),
+              result.header.copy(headers = result.header.headers),
               HttpEntity.Streamed(Source.single(ByteString(compressed)), Some(length.toLong), result.body.contentType)
             )
           }


### PR DESCRIPTION
[NettyModelConversion](https://github.com/playframework/playframework/blob/master/framework/src/play-netty-server/src/main/scala/play/core/server/netty/NettyModelConversion.scala#L189) used in Play 2.5.x computes the content length it self. The compressor provides the content length header manually.

It results in one of these cases:

1. if the lengths are same, it logs `info` and ignores the value
2. if the lengths differ, it logs `warn` and also ignores the manually provided value

Unfortunately, this filter sets wrong content length (possibly with combination with gzip, I have not explored it the reason) , so it logs warnings.

To avoid both these cases, I removed the manually provided content length header.