### PR TITLE
add prefix to give fields unique names

### DIFF
--- a/app/com/mohiva/play/htmlcompressor/HTMLCompressorFilter.scala
+++ b/app/com/mohiva/play/htmlcompressor/HTMLCompressorFilter.scala
@@ -86,5 +86,5 @@ trait HTMLCompressorFilterComponents {
 
   def mat: Materializer
 
-  lazy val filter: HTMLCompressorFilter = new DefaultHTMLCompressorFilter(configuration, environment, mat)
+  lazy val htmlCompressorFilter: HTMLCompressorFilter = new DefaultHTMLCompressorFilter(configuration, environment, mat)
 }

--- a/app/com/mohiva/play/xmlcompressor/XMLCompressorFilter.scala
+++ b/app/com/mohiva/play/xmlcompressor/XMLCompressorFilter.scala
@@ -69,5 +69,5 @@ trait XMLCompressorFilterComponents {
   def configuration: Configuration
   def mat: Materializer
 
-  lazy val filter: XMLCompressorFilter = new DefaultXMLCompressorFilter(configuration, mat)
+  lazy val xmlCompressorFilter: XMLCompressorFilter = new DefaultXMLCompressorFilter(configuration, mat)
 }


### PR DESCRIPTION
When mixing in the Components when using compile-time DI, the name 'filter' is ambiguous and potentially clashes with another field of the same name.