### PR TITLE
Reconstruct HTTP Result in safe way using Result.copy().

### DIFF
--- a/app/com/mohiva/play/compressor/CompressorFilter.scala
+++ b/app/com/mohiva/play/compressor/CompressorFilter.scala
@@ -88,17 +88,31 @@ abstract class CompressorFilter[C <: Compressor] extends Filter {
 
     if (isCompressible(result)) {
       result.body match {
-        case HttpEntity.Strict(data, contentType) =>
-          Future.successful(Result(result.header, HttpEntity.Strict(ByteString(compress(data)), contentType)))
-        case HttpEntity.Streamed(data, _, contentType) =>
-          data.toMat(Sink.fold(ByteString())(_ ++ _))(Keep.right).run() map { bytes =>
+
+        case body0: HttpEntity.Strict =>
+          val result2 = result.copy(
+            body = body0.copy(
+              data = ByteString(compress(body0.data))
+            )
+          )
+          Future.successful(result2)
+
+        case body0: HttpEntity.Streamed =>
+          for {
+            bytes <- body0.data
+              .toMat(Sink.fold(ByteString())(_ ++ _))(Keep.right).run()
+          } yield {
             val compressed = compress(bytes)
             val length = compressed.length
-            Result(
-              result.header.copy(headers = result.header.headers),
-              HttpEntity.Streamed(Source.single(ByteString(compressed)), Some(length.toLong), result.body.contentType)
+            result.copy(
+              //header = result.header.copy(headers = result.header.headers),
+              body = body0.copy(
+                data = Source.single(ByteString(compressed)),
+                contentLength = Some(length.toLong)
+              )
             )
           }
+
         case _ =>
           Future.successful(result)
       }

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ import scalariform.formatter.preferences._
 
 name := "play-html-compressor"
 
-version := "0.7.0"
+version := "0.7.1"
 
 libraryDependencies ++= Seq(
   "com.googlecode.htmlcompressor" % "htmlcompressor" % "1.5.2",

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,6 @@ version := "0.7.1"
 libraryDependencies ++= Seq(
   "com.googlecode.htmlcompressor" % "htmlcompressor" % "1.5.2",
   "rhino" % "js" % "1.7R2",
-  "com.typesafe.play" %% "play-iteratees" % "2.6.1",
   "org.easytesting" % "fest-assert" % "1.4" % Test,
   specs2 % Test,
   javaCore % Test,


### PR DESCRIPTION
This prevents losing some parts of Result like session and other.
Fixes #64