### PR TITLE
Upgrade to Play 2.7.3 and Scala 2.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 scala:
-  - 2.12.2
+  - 2.13.0
+  - 2.12.8
   - 2.11.11
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ This project is not maintained anymore. If someone is interessted to maintain a 
 In your project/Build.scala:
 ```scala
 libraryDependencies ++= Seq(
-  "com.mohiva" %% "play-html-compressor" % "0.7.1"
+  "com.mohiva" %% "play-html-compressor" % "0.8.0"
 )
 ```
 
 ### History
 
+* For Play Framework 2.7 use version 0.8.0
 * For Play Framework 2.6 use version 0.7.1
 * For Play Framework 2.5 use version 0.6.3
 * For Play Framework 2.4 use version 0.5.0
@@ -29,7 +30,7 @@ following two examples shows how to define the filters with the default and the
 user-defined configurations.
 
 To provide the filters for your application you must define it as described in the Play
-Documentation ([Scala](https://www.playframework.com/documentation/2.6.x/ScalaHttpFilters#Using-filters), [Java](https://www.playframework.com/documentation/2.6.x/JavaHttpFilters#Using-filters)).
+Documentation ([Scala](https://www.playframework.com/documentation/2.7.x/ScalaHttpFilters#Using-filters), [Java](https://www.playframework.com/documentation/2.7.x/JavaHttpFilters#Using-filters)).
 
 ### Provide filters
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,7 @@
 import com.typesafe.sbt.SbtScalariform._
 import play.sbt.PlayImport._
-import xerial.sbt.Sonatype._
-
 import scalariform.formatter.preferences._
+import xerial.sbt.Sonatype._
 
 //*******************************
 // Play settings
@@ -10,7 +9,7 @@ import scalariform.formatter.preferences._
 
 name := "play-html-compressor"
 
-version := "0.7.1"
+version := "0.8.0"
 
 libraryDependencies ++= Seq(
   "com.googlecode.htmlcompressor" % "htmlcompressor" % "1.5.2",
@@ -21,7 +20,7 @@ libraryDependencies ++= Seq(
   filters % Test
 )
 
-lazy val root = (project in file(".")).enablePlugins(play.sbt.Play)
+lazy val root = (project in file(".")).enablePlugins(play.sbt.PlayWeb)
 
 //*******************************
 // Maven settings
@@ -38,9 +37,9 @@ homepage := Some(url("https://github.com/mohiva/play-html-compressor/"))
 licenses := Seq("BSD New" -> url("https://github.com/mohiva/play-html-compressor/blob/master/LICENSE.md"))
 
 val pom = <scm>
-    <url>git@github.com:mohiva/play-html-compressor.git</url>
-    <connection>scm:git:git@github.com:mohiva/play-html-compressor.git</connection>
-  </scm>
+  <url>git@github.com:mohiva/play-html-compressor.git</url>
+  <connection>scm:git:git@github.com:mohiva/play-html-compressor.git</connection>
+</scm>
   <developers>
     <developer>
       <id>akkie</id>
@@ -61,25 +60,37 @@ pomExtra := pom
 // Compiler settings
 //*******************************
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.13.0"
 
-crossScalaVersions := Seq("2.12.2", "2.11.11")
+crossScalaVersions := Seq("2.13.0", "2.12.8", "2.11.11")
 
-scalacOptions ++= Seq(
-  "-deprecation", // Emit warning and location for usages of deprecated APIs.
-  "-feature", // Emit warning and location for usages of features that should be imported explicitly.
-  "-unchecked", // Enable additional warnings where generated code depends on assumptions.
-  "-Xfatal-warnings", // Fail the compilation if there are any warnings.
-  "-Xlint", // Enable recommended additional warnings.
-  "-Ywarn-adapted-args", // Warn if an argument list is modified to match the receiver.
-  "-Ywarn-dead-code", // Warn when dead code is identified.
-  "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
-  "-Ywarn-nullary-override", // Warn when non-nullary overrides nullary, e.g. def foo() over def foo.
-  "-Ywarn-numeric-widen" // Warn when numerics are widened.
-)
+scalacOptions ++= PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)) {
+  case Some((2, v)) if v >= 11 && v <= 12 => Seq(
+    "-deprecation", // Emit warning and location for usages of deprecated APIs.
+    "-feature", // Emit warning and location for usages of features that should be imported explicitly.
+    "-unchecked", // Enable additional warnings where generated code depends on assumptions.
+    "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+    "-Xlint", // Enable recommended additional warnings.
+    "-Ywarn-adapted-args", // Warn if an argument list is modified to match the receiver.
+    "-Ywarn-dead-code", // Warn when dead code is identified.
+    "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
+    "-Ywarn-nullary-override", // Warn when non-nullary overrides nullary, e.g. def foo() over def foo.
+    "-Ywarn-numeric-widen" // Warn when numerics are widened.
+  )
+  case Some((2, 13)) =>
+    Seq(
+      "-deprecation", // Emit warning and location for usages of deprecated APIs.
+      "-feature", // Emit warning and location for usages of features that should be imported explicitly.
+      "-unchecked", // Enable additional warnings where generated code depends on assumptions.
+      "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+      "-Xlint", // Enable recommended additional warnings.
+      "-Ywarn-dead-code", // Warn when dead code is identified.
+      "-Ywarn-numeric-widen" // Warn when numerics are widened.
+    )
+}.toList.flatten
 
 // Allow dead code in tests (to support using mockito).
-scalacOptions in Test ~= { (options: Seq[String]) => options filterNot ( _ == "-Ywarn-dead-code" ) }
+scalacOptions in Test ~= { (options: Seq[String]) => options filterNot (_ == "-Ywarn-dead-code") }
 
 javacOptions ++= Seq(
   "-Xlint:deprecation"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.18

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 

--- a/test/com/mohiva/play/htmlcompressor/HTMLCompressorFilterSpec.scala
+++ b/test/com/mohiva/play/htmlcompressor/HTMLCompressorFilterSpec.scala
@@ -31,7 +31,7 @@ class HTMLCompressorFilterSpec extends Specification {
   "The default filter" should {
     "compress an HTML page" in new Context {
       new WithApplication(defaultApp) {
-        val Some(result) = route(defaultApp, FakeRequest(GET, "/action"))
+        val result = route(defaultApp, FakeRequest(GET, "/action")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("text/html")
@@ -41,7 +41,7 @@ class HTMLCompressorFilterSpec extends Specification {
 
     "compress an async HTML page" in new Context {
       new WithApplication(defaultApp) {
-        val Some(result) = route(defaultApp, FakeRequest(GET, "/asyncAction"))
+        val result = route(defaultApp, FakeRequest(GET, "/asyncAction")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("text/html")
@@ -51,7 +51,7 @@ class HTMLCompressorFilterSpec extends Specification {
 
     "not compress a non HTML result" in new Context {
       new WithApplication(defaultApp) {
-        val Some(result) = route(defaultApp, FakeRequest(GET, "/nonHTML"))
+        val result = route(defaultApp, FakeRequest(GET, "/nonHTML")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("text/plain")
@@ -62,7 +62,7 @@ class HTMLCompressorFilterSpec extends Specification {
     "compress static assets" in new Context {
       new WithApplication(defaultApp) {
         val file = scala.io.Source.fromInputStream(environment.resourceAsStream("static.html").get).mkString
-        val Some(result) = route(defaultApp, FakeRequest(GET, "/static"))
+        val result = route(defaultApp, FakeRequest(GET, "/static")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("text/html")
@@ -73,7 +73,7 @@ class HTMLCompressorFilterSpec extends Specification {
 
     "not compress result with chunked HTML result" in new Context {
       new WithApplication(defaultApp) {
-        val Some(result) = route(defaultApp, FakeRequest(GET, "/chunked"))
+        val result = route(defaultApp, FakeRequest(GET, "/chunked")).get
         status(result) must beEqualTo(OK)
         contentType(result) must beSome("text/html")
         header(CONTENT_LENGTH, result) must beNone
@@ -84,7 +84,7 @@ class HTMLCompressorFilterSpec extends Specification {
   "The custom filter" should {
     "compress an HTML page" in new Context {
       new WithApplication(customApp) {
-        val Some(result) = route(customApp, FakeRequest(GET, "/action"))
+        val result = route(customApp, FakeRequest(GET, "/action")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("text/html")
@@ -94,7 +94,7 @@ class HTMLCompressorFilterSpec extends Specification {
 
     "compress an async HTML page" in new Context {
       new WithApplication(customApp) {
-        val Some(result) = route(customApp, FakeRequest(GET, "/asyncAction"))
+        val result = route(customApp, FakeRequest(GET, "/asyncAction")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("text/html")
@@ -104,7 +104,7 @@ class HTMLCompressorFilterSpec extends Specification {
 
     "not compress a non HTML result" in new Context {
       new WithApplication(customApp) {
-        val Some(result) = route(customApp, FakeRequest(GET, "/nonHTML"))
+        val result = route(customApp, FakeRequest(GET, "/nonHTML")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("text/plain")
@@ -115,7 +115,7 @@ class HTMLCompressorFilterSpec extends Specification {
     "compress static assets" in new Context {
       new WithApplication(customApp) {
         val file = scala.io.Source.fromInputStream(environment.resourceAsStream("static.html").get).mkString
-        val Some(result) = route(customApp, FakeRequest(GET, "/static"))
+        val result = route(customApp, FakeRequest(GET, "/static")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("text/html")
@@ -128,8 +128,8 @@ class HTMLCompressorFilterSpec extends Specification {
   "The default filter with Gzip Filter" should {
     "first compress then gzip result" in new Context {
       new WithApplication(gzipApp) {
-        val Some(original) = route(gzipApp, FakeRequest(GET, "/action"))
-        val Some(gzipped) = route(gzipApp, FakeRequest(GET, "/action").withHeaders(ACCEPT_ENCODING -> "gzip"))
+        val original = route(gzipApp, FakeRequest(GET, "/action")).get
+        val gzipped = route(gzipApp, FakeRequest(GET, "/action").withHeaders(ACCEPT_ENCODING -> "gzip")).get
 
         status(gzipped) must beEqualTo(OK)
         contentType(gzipped) must beSome("text/html")
@@ -146,7 +146,7 @@ class HTMLCompressorFilterSpec extends Specification {
         // we don't want to further pass this through HTML Compressor
 
         val original = ByteString(IOUtils.toByteArray(environment.resourceAsStream("static.html").get))
-        val Some(result) = route(gzipApp, FakeRequest(GET, "/gzipped").withHeaders(ACCEPT_ENCODING -> "gzip"))
+        val result = route(gzipApp, FakeRequest(GET, "/gzipped").withHeaders(ACCEPT_ENCODING -> "gzip")).get
 
         status(result) must beEqualTo(OK)
         contentType(result) must beSome("text/html")

--- a/test/com/mohiva/play/htmlcompressor/fixtures/RequestHandler.scala
+++ b/test/com/mohiva/play/htmlcompressor/fixtures/RequestHandler.scala
@@ -11,11 +11,11 @@
 package com.mohiva.play.htmlcompressor.fixtures
 
 import javax.inject.Inject
-
 import controllers.AssetsMetadata
 import play.api.http.{ DefaultHttpRequestHandler, HttpConfiguration, HttpErrorHandler, HttpFilters }
 import play.api.mvc.{ ControllerComponents, Handler, RequestHeader }
 import play.api.routing.Router
+import play.core.WebCommands
 
 /**
  * Request handler which defines the routes for the tests.
@@ -26,8 +26,10 @@ class RequestHandler @Inject() (
   configuration: HttpConfiguration,
   filters: HttpFilters,
   components: ControllerComponents,
-  meta: AssetsMetadata)
-  extends DefaultHttpRequestHandler(router, errorHandler, configuration, filters) {
+  meta: AssetsMetadata,
+  webCommands: WebCommands
+)
+  extends DefaultHttpRequestHandler(webCommands, None, router, errorHandler, configuration, filters.filters) {
 
   /**
    * Specify custom routes for this test.

--- a/test/com/mohiva/play/xmlcompressor/XMLCompressorFilterSpec.scala
+++ b/test/com/mohiva/play/xmlcompressor/XMLCompressorFilterSpec.scala
@@ -31,7 +31,7 @@ class XMLCompressorFilterSpec extends Specification {
   "The default filter" should {
     "compress an XML document" in new Context {
       new WithApplication(defaultApp) {
-        val Some(result) = route(gzipApp, FakeRequest(GET, "/action"))
+        val result = route(gzipApp, FakeRequest(GET, "/action")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("application/xml")
@@ -41,7 +41,7 @@ class XMLCompressorFilterSpec extends Specification {
 
     "compress an async XML document" in new Context {
       new WithApplication(defaultApp) {
-        val Some(result) = route(gzipApp, FakeRequest(GET, "/asyncAction"))
+        val result = route(gzipApp, FakeRequest(GET, "/asyncAction")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("application/xml")
@@ -51,7 +51,7 @@ class XMLCompressorFilterSpec extends Specification {
 
     "not compress a non XML result" in new Context {
       new WithApplication(defaultApp) {
-        val Some(result) = route(gzipApp, FakeRequest(GET, "/nonXML"))
+        val result = route(gzipApp, FakeRequest(GET, "/nonXML")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("text/plain")
@@ -61,7 +61,7 @@ class XMLCompressorFilterSpec extends Specification {
 
     "not compress chunked XML result" in new Context {
       new WithApplication(defaultApp) {
-        val Some(result) = route(gzipApp, FakeRequest(GET, "/chunked"))
+        val result = route(gzipApp, FakeRequest(GET, "/chunked")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("application/xml")
@@ -72,7 +72,7 @@ class XMLCompressorFilterSpec extends Specification {
     "compress static XML assets" in new Context {
       new WithApplication(defaultApp) {
         val file = scala.io.Source.fromInputStream(environment.resourceAsStream("static.xml").get).mkString
-        val Some(result) = route(gzipApp, FakeRequest(GET, "/static"))
+        val result = route(gzipApp, FakeRequest(GET, "/static")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("application/xml")
@@ -85,7 +85,7 @@ class XMLCompressorFilterSpec extends Specification {
   "The custom filter" should {
     "compress an XML document" in new Context {
       new WithApplication(customApp) {
-        val Some(result) = route(gzipApp, FakeRequest(GET, "/action"))
+        val result = route(gzipApp, FakeRequest(GET, "/action")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("application/xml")
@@ -95,7 +95,7 @@ class XMLCompressorFilterSpec extends Specification {
 
     "compress an async XML document" in new Context {
       new WithApplication(customApp) {
-        val Some(result) = route(gzipApp, FakeRequest(GET, "/asyncAction"))
+        val result = route(gzipApp, FakeRequest(GET, "/asyncAction")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("application/xml")
@@ -105,7 +105,7 @@ class XMLCompressorFilterSpec extends Specification {
 
     "not compress a non XML result" in new Context {
       new WithApplication(customApp) {
-        val Some(result) = route(gzipApp, FakeRequest(GET, "/nonXML"))
+        val result = route(gzipApp, FakeRequest(GET, "/nonXML")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("text/plain")
@@ -116,7 +116,7 @@ class XMLCompressorFilterSpec extends Specification {
     "compress static XML assets" in new Context {
       new WithApplication(customApp) {
         val file = scala.io.Source.fromInputStream(environment.resourceAsStream("static.xml").get).mkString
-        val Some(result) = route(gzipApp, FakeRequest(GET, "/static"))
+        val result = route(gzipApp, FakeRequest(GET, "/static")).get
 
         status(result) must equalTo(OK)
         contentType(result) must beSome("application/xml")
@@ -129,8 +129,8 @@ class XMLCompressorFilterSpec extends Specification {
   "The default filter with Gzip Filter" should {
     "first compress then gzip result" in new Context {
       new WithApplication(gzipApp) {
-        val Some(original) = route(gzipApp, FakeRequest(GET, "/action"))
-        val Some(gzipped) = route(gzipApp, FakeRequest(GET, "/action").withHeaders(ACCEPT_ENCODING -> "gzip"))
+        val original = route(gzipApp, FakeRequest(GET, "/action")).get
+        val gzipped = route(gzipApp, FakeRequest(GET, "/action").withHeaders(ACCEPT_ENCODING -> "gzip")).get
 
         status(gzipped) must beEqualTo(OK)
         contentType(gzipped) must beSome("application/xml")
@@ -147,7 +147,7 @@ class XMLCompressorFilterSpec extends Specification {
         // we don't want to further pass this through XML Compressor
 
         val original = ByteString(IOUtils.toByteArray(environment.resourceAsStream("static.xml").get))
-        val Some(result) = route(gzipApp, FakeRequest(GET, "/gzipped").withHeaders(ACCEPT_ENCODING -> "gzip"))
+        val result = route(gzipApp, FakeRequest(GET, "/gzipped").withHeaders(ACCEPT_ENCODING -> "gzip")).get
 
         status(result) must beEqualTo(OK)
         contentType(result) must beSome("application/xml")

--- a/test/com/mohiva/play/xmlcompressor/fixtures/RequestHandler.scala
+++ b/test/com/mohiva/play/xmlcompressor/fixtures/RequestHandler.scala
@@ -11,11 +11,11 @@
 package com.mohiva.play.xmlcompressor.fixtures
 
 import javax.inject.Inject
-
 import controllers.AssetsMetadata
 import play.api.http.{ DefaultHttpRequestHandler, HttpConfiguration, HttpErrorHandler, HttpFilters }
 import play.api.mvc.{ ControllerComponents, Handler, RequestHeader }
 import play.api.routing.Router
+import play.core.WebCommands
 
 /**
  * Request handler which defines the routes for the tests.
@@ -26,8 +26,10 @@ class RequestHandler @Inject() (
   configuration: HttpConfiguration,
   filters: HttpFilters,
   components: ControllerComponents,
-  meta: AssetsMetadata)
-  extends DefaultHttpRequestHandler(router, errorHandler, configuration, filters) {
+  meta: AssetsMetadata,
+  webCommands: WebCommands
+)
+  extends DefaultHttpRequestHandler(webCommands, None, router, errorHandler, configuration, filters.filters) {
 
   /**
    * Specify custom routes for this test.


### PR DESCRIPTION
In order to allow the upgrade some compiler options are not set
depending on the version of Scala used.

Some extraction of Some() values in tests for Scala 2.13 had to be
changed.

Deprecated constructor DefaultHttpRequestHandler replaced with
recommended version.

Bumped to sbt 0.13.18.